### PR TITLE
Add `urdh` prompt theme

### DIFF
--- a/themes/urdh/ReadMe.md
+++ b/themes/urdh/ReadMe.md
@@ -1,0 +1,27 @@
+# urdh
+
+urdh provides a pretty simple prompt, with support [Git][] and [Mercurial][].
+
+![urdh prompt screenshot][screenshot]
+
+## Requirements
+
+### vcprompt
+
+You **must** have [vcprompt][] installed to use this theme, which on Mac OS X can be done via:
+
+    brew install vcprompt
+
+Why the hard requirement? Determining whether the current working directory is under version control is cumbersome and adds latency to the prompt. It doesn't make sense to have a slow terminal prompt on a 3+ GHz machine, right? [vcprompt][] is a tiny C program that is also extremely fast, which makes it perfectly suited to making this determination.
+
+If you only use Git, then you're all ready to go.
+
+### hg-prompt
+
+If you use Mercurial, you'll also need to install [hg-prompt][], which populates the prompt with relevant information when the current working directory is inside a Mercurial repository.
+
+[hg-prompt]: http://sjl.bitbucket.org/hg-prompt/
+[Git]: http://git-scm.com/
+[Mercurial]: http://mercurial.selenic.com/
+[screenshot]: http://i.imgur.com/zoa85vj.png
+[vcprompt]: https://bitbucket.org/gward/vcprompt

--- a/themes/urdh/fish_greeting.fish
+++ b/themes/urdh/fish_greeting.fish
@@ -1,0 +1,11 @@
+# urdh prompt theme, by Simon Sigurdhsson <http://github.com/urdh/>
+function fish_greeting --description 'Print the shell greeting'
+    set -l c_n (set_color normal)
+    set -l c_w (set_color cyan)
+
+    set -l location (printf "%sWelcome to %s%s%s" $c_n $c_w (hostname) $c_n)
+    set -l system (printf "%sRunning %s%s%s on %s%s%s" $c_n $c_w (uname -mrs) $c_n $c_w (tty | sed -e 's/.*tty\(.*\)/\1/') $c_n)
+    set -l datetime (printf "%sIt is %s%s%s (%s) on %s%s%s" $c_n $c_w (date +%T) $c_n (date +%Z) $c_w (date +%F) $c_n)
+
+    printf "\n  %s\n  %s\n  %s\n\n" $location $system $datetime
+end

--- a/themes/urdh/fish_prompt.fish
+++ b/themes/urdh/fish_prompt.fish
@@ -1,0 +1,39 @@
+# urdh prompt theme, by Simon Sigurdhsson <http://github.com/urdh/>
+function _urdh_theme_user --description 'Print user name'
+    switch $USER
+        case root
+            printf '%s%s%s' (set_color red) $USER (set_color normal)
+        case '*'
+            printf '%s' $USER
+    end
+end
+
+function _urdh_theme_cwd --description 'Print current working directory'
+    printf '%s%s%s' (set_color $fish_color_cwd) (prompt_pwd) (set_color normal)
+end
+
+function _urdh_theme_vcs --description 'Write out the VCS prompt'
+    set -l ___vcs (vcprompt -f '%n')
+    if test -n "$___vcs"
+        switch $___vcs
+            case 'git*'
+                set -g __fish_git_prompt_color_branch 'black' '--bold'
+                set -g __fish_git_prompt_color_merging 'red' '--bold'
+                __fish_git_prompt ' %s'
+            case 'hg*'
+                printf ' %s%s%s' (set_color -o black) (vcprompt -f '%b') (set_color normal)
+        end
+    end
+end
+
+function fish_prompt --description 'Write out the prompt'
+    # precalc some variables
+    if not set -q _urdh_theme_hostname
+        set -g _urdh_theme_hostname (hostname|cut -d . -f 1)
+    end
+    # print the prompt
+    set -l ___host (printf '%s@%s' (_urdh_theme_user) $_urdh_theme_hostname)
+    set -l ___cwd (_urdh_theme_cwd)
+    set -l ___vcs (printf '%s%s' (_urdh_theme_vcs))
+    printf '%s %s%s> ' $___host $___cwd $___vcs
+end

--- a/themes/urdh/fish_right_prompt.fish
+++ b/themes/urdh/fish_right_prompt.fish
@@ -1,0 +1,51 @@
+# urdh prompt theme, by Simon Sigurdhsson <http://github.com/urdh/>
+function fish_right_prompt --description 'Write out the right-hand prompt'
+    set -l ___vcs (vcprompt -f '%n')
+    if test -n "$___vcs"
+        switch $___vcs
+            case 'git*'
+                set -l __fish_git_prompt_showstashstate 'yes'
+                set -l __fish_git_prompt_showdirtystate 'yes'
+                set -l __fish_git_prompt_showuntrackedfiles 'yes'
+                set -l __fish_git_prompt_show_informative_status 'yes'
+                set -l __fish_git_prompt_showupstream 'informative git'
+
+                set -g ___fish_git_prompt_color_cleanstate (set_color --bold green)
+                set -g ___fish_git_prompt_color_stagedstate (set_color --bold green)
+                set -g ___fish_git_prompt_color_invalidstate (set_color --bold red)
+                set -g ___fish_git_prompt_color_dirtystate (set_color --bold yellow)
+                set -g ___fish_git_prompt_color_untrackedfiles (set_color --bold red)
+                set -g ___fish_git_prompt_color_stashstate (set_color --bold cyan)
+
+                set -g ___fish_git_prompt_char_upstream_equal ''
+                set -g ___fish_git_prompt_char_upstream_ahead '⬘'
+                set -g ___fish_git_prompt_char_upstream_behind '⬙'
+                set -g ___fish_git_prompt_char_upstream_diverged '⬥'
+                set -g ___fish_git_prompt_char_stateseparator ''
+                set -g ___fish_git_prompt_char_dirtystate '●'
+                set -g ___fish_git_prompt_char_invalidstate '⦻'
+                set -g ___fish_git_prompt_char_stagedstate '●'
+                set -g ___fish_git_prompt_char_untrackedfiles '○'
+                set -g ___fish_git_prompt_char_cleanstate '✔ '
+                set -g ___fish_git_prompt_char_stashstate '▣'
+
+                set -g __fish_git_prompt_hide_dirtystate 'yes'
+                set -g __fish_git_prompt_hide_invalidstate 'yes'
+                set -g __fish_git_prompt_hide_stagedstate 'yes'
+                set -g __fish_git_prompt_hide_untrackedfiles 'yes'
+
+                set -l i (__fish_git_prompt_informative_status)
+                set -l s
+                if test -r (command git rev-parse --git-dir)/refs/stash
+				            set s $___fish_git_prompt_char_stashstate
+                    set s "$___fish_git_prompt_color_stashstate$s"
+                    set s "$s$___fish_git_prompt_color_stashstate_done"
+			          end
+                set -l u (__fish_git_prompt_show_upstream)
+
+                printf '%s%s%s%s%s' $i (set_color -o black) $s $u (set_color normal)
+            case 'hg*'
+                printf ' %s%s%s' (set_color -o red) (hg prompt '{status}') (set_color normal)
+        end
+    end
+end

--- a/themes/urdh/fish_title.fish
+++ b/themes/urdh/fish_title.fish
@@ -1,0 +1,22 @@
+# urdh prompt theme, by Simon Sigurdhsson <http://github.com/urdh/>
+function fish_title --description 'Set terminal title'
+    if set -q fish_title_disabled
+        return
+    end
+
+    set -l pwd (prompt_pwd)
+    switch "$_"
+        case 'ssh'
+            set -g fish_title_string 'ssh'
+        case 'fish'
+            set -g fish_title_string (printf 'idle in %s' $pwd)
+        case '*'
+            set -g fish_title_string (printf 'running %s in %s' $_ $pwd)
+    end
+
+    if test -n "$SSH_CONNECTION"
+        printf 'fish on %s: %s' (hostname|cut -d . -f 1) $fish_title_string
+    else
+        printf 'fish: %s' $fish_title_string
+    end
+end


### PR DESCRIPTION
A theme with git and mercurial support, including a right prompt. Also includes `fish_greeting` and `fish_title` functions.

![urdh prompt screenshot](http://i.imgur.com/zoa85vj.png)
