### PR TITLE
Update fish completions *after* upgrading brew/tlmgr

### DIFF
--- a/plugins/up/up.fish
+++ b/plugins/up/up.fish
@@ -1,7 +1,6 @@
 # up: https://github.com/justinmayer/tackle/tree/master/plugins/up
 function up -d "Update software to the latest versions"
     if contains "all" $argv
-        fish_update_completions
         type brew >/dev/null
         and begin
             brew update
@@ -15,6 +14,7 @@ function up -d "Update software to the latest versions"
                 up $plugin
             end
         end
+        fish_update_completions
     else
         for arg in $argv
             if contains $arg $fish_plugins


### PR DESCRIPTION
This makes more sense as brew and/or tlmgr may introduce new version of the manual pages fish parses for completions.
