### PR TITLE
Modify budspencer theme

### DIFF
--- a/themes/budspencer/fish_prompt.fish
+++ b/themes/budspencer/fish_prompt.fish
@@ -114,11 +114,19 @@ function __budspencer_preexec -d 'Execute after hitting <Enter> before doing any
     commandline -f execute
 end
 
+#####################
+# => Fish termination
+#####################
+function __budspencer_on_termination -s HUP -s INT -s QUIT -s TERM --on-process %self -d 'Execute when shell terminates'
+    set -l item (contains -i %self $budspencer_sessions_active_pid ^ /dev/null)
+    __budspencer_detach_session $item
+end
+
 ######################
 # => Directory history
 ######################
 function __budspencer_create_dir_hist -v PWD -d 'Create directory history without duplicates'
-    if [ $pwd_hist_lock = false ]
+    if [ "$pwd_hist_lock" = false ]
         if contains $PWD $$dir_hist
             set -e $dir_hist[1][(contains -i $PWD $$dir_hist)]
         end
@@ -486,7 +494,7 @@ function __budspencer_prompt_bindmode -d 'Displays the current mode'
     case insert
         set budspencer_current_bindmode_color $budspencer_colors[5]
         echo -en $budspencer_cursors[2]
-        if [ $pwd_hist_lock = true ]
+        if [ "$pwd_hist_lock" = true ]
             set pwd_hist_lock false
             __budspencer_create_dir_hist
         end
@@ -679,5 +687,5 @@ set -x LOGIN $USER
 
 function fish_prompt -d 'Write out the left prompt of the budspencer theme'
     set -g last_status $status
-        echo -n -s (__budspencer_prompt_bindmode) (__budspencer_prompt_git_branch) (__budspencer_prompt_left_symbols) '' ' '
+    echo -n -s (__budspencer_prompt_bindmode) (__budspencer_prompt_git_branch) (__budspencer_prompt_left_symbols) '' ' '
 end

--- a/themes/budspencer/fish_right_prompt.fish
+++ b/themes/budspencer/fish_right_prompt.fish
@@ -94,19 +94,20 @@ function __budspencer_git_status -d 'Check git status'
 end
 
 function __budspencer_is_git_stashed -d 'Check if there are stashed commits'
-    command git stash list ^ /dev/null  | wc -l
+    command git log --format="%gd" -g $argv 'refs/stash' -- ^ /dev/null | wc -l
 end
 
 function __budspencer_prompt_git_symbols -d 'Displays the git symbols'
     set -l is_repo (command git rev-parse --is-inside-work-tree ^/dev/null)
+    if [ -z $is_repo ]
+        return
+    end
+
     set -l git_ahead_behind (__budspencer_is_git_ahead_or_behind)
     set -l git_status (__budspencer_git_status)
     set -l git_stashed (__budspencer_is_git_stashed)
 
-    if begin
-        [ $is_repo=true ]
-        [ (expr $git_status[1] + $git_status[2] + $git_status[3] + $git_status[4] + $git_status[5] + $git_status[6]) -ne 0 ]
-    end
+    if [ (expr $git_status[1] + $git_status[2] + $git_status[3] + $git_status[4] + $git_status[5] + $git_status[6] + $git_stashed) -ne 0 ]
         set_color $budspencer_colors[3]
         echo -n ''
         set_color -b $budspencer_colors[3]


### PR DESCRIPTION
Bugfix: Stashed commits were not shown in case there were no other git symbols.
Improvement: The slow `git stash list` command was replaced, should result in a
much better performance.
