### PR TITLE
Homebrew will soon require the --all flag for `brew upgrade`

### DIFF
--- a/plugins/up/up.fish
+++ b/plugins/up/up.fish
@@ -4,7 +4,7 @@ function up -d "Update software to the latest versions"
         which brew >/dev/null
         and begin
             brew update
-            brew upgrade
+            brew upgrade --all
         end
         which tlmgr >/dev/null
         and  tlmgr update --self --all


### PR DESCRIPTION
Use the `--all` flag with `brew upgrade`. There's some discussion on this in Homebrew/homebrew#35985, I think.