### PR TITLE
Remove --all from brew upgrade

### DIFF
--- a/plugins/up/up.fish
+++ b/plugins/up/up.fish
@@ -6,7 +6,7 @@ function up -d "Update software to the latest versions"
         which brew >/dev/null 2>&1
         and begin
             brew update
-            brew upgrade --all
+            brew upgrade
         end
         which port >/dev/null 2>&1
         and begin


### PR DESCRIPTION
Homebrew decided not to change the behavior of brew upgrade. Running
the command with --all will display a warning message.