### PR TITLE
Add grc command colorizers

### DIFF
--- a/plugins/grc/ant.fish
+++ b/plugins/grc/ant.fish
@@ -1,0 +1,3 @@
+function ant -d "ant with colorized output"
+    _colorize ant $argv
+end

--- a/plugins/grc/blkid.fish
+++ b/plugins/grc/blkid.fish
@@ -1,0 +1,3 @@
+function blkid -d "blkid with colorized output"
+    _colorize blkid $argv
+end

--- a/plugins/grc/cvs.fish
+++ b/plugins/grc/cvs.fish
@@ -1,0 +1,3 @@
+function cvs -d "cvs with colorized output"
+    _colorize cvs $argv
+end

--- a/plugins/grc/df.fish
+++ b/plugins/grc/df.fish
@@ -1,3 +1,3 @@
 function df -d "df with colorized output"
-    _colorize --config=conf.df df $argv
+    _colorize df $argv
 end

--- a/plugins/grc/dnf.fish
+++ b/plugins/grc/dnf.fish
@@ -1,0 +1,3 @@
+function dnf -d "dnf with colorized output"
+    _colorize dnf $argv
+end

--- a/plugins/grc/docker.fish
+++ b/plugins/grc/docker.fish
@@ -1,0 +1,3 @@
+function docker -d "docker with colorized output"
+    _colorize docker $argv
+end

--- a/plugins/grc/du.fish
+++ b/plugins/grc/du.fish
@@ -1,0 +1,3 @@
+function du -d "du with colorized output"
+    _colorize du $argv
+end

--- a/plugins/grc/env.fish
+++ b/plugins/grc/env.fish
@@ -1,0 +1,3 @@
+function env -d "env with colorized output"
+    _colorize env $argv
+end

--- a/plugins/grc/free.fish
+++ b/plugins/grc/free.fish
@@ -1,0 +1,3 @@
+function free -d "free with colorized output"
+    _colorize free $argv
+end

--- a/plugins/grc/getsebool.fish
+++ b/plugins/grc/getsebool.fish
@@ -1,0 +1,3 @@
+function getsebool -d "getsebool with colorized output"
+    _colorize getsebool $argv
+end

--- a/plugins/grc/iostat.fish
+++ b/plugins/grc/iostat.fish
@@ -1,0 +1,3 @@
+function iostat -d "iostat with colorized output"
+    _colorize iostat $argv
+end

--- a/plugins/grc/ip.fish
+++ b/plugins/grc/ip.fish
@@ -1,0 +1,3 @@
+function ip -d "ip with colorized output"
+    _colorize ip $argv
+end

--- a/plugins/grc/iptables.fish
+++ b/plugins/grc/iptables.fish
@@ -1,0 +1,3 @@
+function iptables -d "iptables with colorized output"
+    _colorize iptables $argv
+end

--- a/plugins/grc/last.fish
+++ b/plugins/grc/last.fish
@@ -1,0 +1,3 @@
+function last -d "last with colorized output"
+    _colorize last $argv
+end

--- a/plugins/grc/ls.fish
+++ b/plugins/grc/ls.fish
@@ -1,0 +1,3 @@
+function ls -d "ls with colorized output"
+    _colorize ls $argv
+end

--- a/plugins/grc/lsattr.fish
+++ b/plugins/grc/lsattr.fish
@@ -1,0 +1,3 @@
+function lsattr -d "lsattr with colorized output"
+    _colorize lsattr $argv
+end

--- a/plugins/grc/lsmod.fish
+++ b/plugins/grc/lsmod.fish
@@ -1,0 +1,3 @@
+function lsmod -d "lsmod with colorized output"
+    _colorize lsmod $argv
+end

--- a/plugins/grc/lspci.fish
+++ b/plugins/grc/lspci.fish
@@ -1,0 +1,3 @@
+function lspci -d "lspci with colorized output"
+    _colorize lspci $argv
+end

--- a/plugins/grc/mount.fish
+++ b/plugins/grc/mount.fish
@@ -1,0 +1,3 @@
+function mount -d "mount with colorized output"
+    _colorize mount $argv
+end

--- a/plugins/grc/mtr.fish
+++ b/plugins/grc/mtr.fish
@@ -1,0 +1,3 @@
+function mtr -d "mtr with colorized output"
+    _colorize mtr $argv
+end

--- a/plugins/grc/mvn.fish
+++ b/plugins/grc/mvn.fish
@@ -1,0 +1,3 @@
+function mvn -d "mvn with colorized output"
+    _colorize mvn $argv
+end

--- a/plugins/grc/nmap.fish
+++ b/plugins/grc/nmap.fish
@@ -1,0 +1,3 @@
+function nmap -d "nmap with colorized output"
+    _colorize nmap $argv
+end

--- a/plugins/grc/php.fish
+++ b/plugins/grc/php.fish
@@ -1,0 +1,3 @@
+function php -d "php with colorized output"
+    _colorize php $argv
+end

--- a/plugins/grc/pv.fish
+++ b/plugins/grc/pv.fish
@@ -1,0 +1,3 @@
+function pv -d "pv with colorized output"
+    _colorize pv $argv
+end

--- a/plugins/grc/sar.fish
+++ b/plugins/grc/sar.fish
@@ -1,0 +1,3 @@
+function sar -d "sar with colorized output"
+    _colorize sar $argv
+end

--- a/plugins/grc/semanage.fish
+++ b/plugins/grc/semanage.fish
@@ -1,0 +1,3 @@
+function semanage -d "semanage with colorized output"
+    _colorize semanage $argv
+end

--- a/plugins/grc/showmount.fish
+++ b/plugins/grc/showmount.fish
@@ -1,0 +1,3 @@
+function showmount -d "showmount with colorized output"
+    _colorize showmount $argv
+end

--- a/plugins/grc/ss.fish
+++ b/plugins/grc/ss.fish
@@ -1,0 +1,3 @@
+function ss -d "ss with colorized output"
+    _colorize ss $argv
+end

--- a/plugins/grc/stat.fish
+++ b/plugins/grc/stat.fish
@@ -1,0 +1,3 @@
+function stat -d "stat with colorized output"
+    _colorize stat $argv
+end

--- a/plugins/grc/sysctl.fish
+++ b/plugins/grc/sysctl.fish
@@ -1,0 +1,3 @@
+function sysctl -d "sysctl with colorized output"
+    _colorize sysctl $argv
+end

--- a/plugins/grc/systemctl.fish
+++ b/plugins/grc/systemctl.fish
@@ -1,0 +1,3 @@
+function systemctl -d "systemctl with colorized output"
+    _colorize systemctl $argv
+end

--- a/plugins/grc/tcpdump.fish
+++ b/plugins/grc/tcpdump.fish
@@ -1,0 +1,3 @@
+function tcpdump -d "tcpdump with colorized output"
+    _colorize tcpdump $argv
+end

--- a/plugins/grc/traceroute.fish
+++ b/plugins/grc/traceroute.fish
@@ -1,0 +1,3 @@
+function traceroute -d "traceroute with colorized output"
+    _colorize traceroute $argv
+end

--- a/plugins/grc/tune2fs.fish
+++ b/plugins/grc/tune2fs.fish
@@ -1,0 +1,3 @@
+function tune2fs -d "tune2fs with colorized output"
+    _colorize tune2fs $argv
+end

--- a/plugins/grc/ulimit.fish
+++ b/plugins/grc/ulimit.fish
@@ -1,0 +1,3 @@
+function ulimit -d "ulimit with colorized output"
+    _colorize ulimit $argv
+end

--- a/plugins/grc/uptime.fish
+++ b/plugins/grc/uptime.fish
@@ -1,0 +1,3 @@
+function uptime -d "uptime with colorized output"
+    _colorize uptime $argv
+end

--- a/plugins/grc/vmstat.fish
+++ b/plugins/grc/vmstat.fish
@@ -1,0 +1,3 @@
+function vmstat -d "vmstat with colorized output"
+    _colorize vmstat $argv
+end

--- a/plugins/grc/wdiff.fish
+++ b/plugins/grc/wdiff.fish
@@ -1,0 +1,3 @@
+function wdiff -d "wdiff with colorized output"
+    _colorize wdiff $argv
+end


### PR DESCRIPTION
grc includes a number of additional colorizing filters for commands
not already included in tackle (https://github.com/garabik/grc).
I have added most of them in this commit. Several of the filters
from the grc repo have been left out (such as conf.sql, conf.irclog,
etc.) because those are intended for colorizing log files and scripts
rather than command output.