### PR TITLE
budspencer theme: Strip spaces from return from git stash

### DIFF
--- a/themes/budspencer/fish_right_prompt.fish
+++ b/themes/budspencer/fish_right_prompt.fish
@@ -94,7 +94,8 @@ function __budspencer_git_status -d 'Check git status'
 end
 
 function __budspencer_is_git_stashed -d 'Check if there are stashed commits'
-    command git log --format="%gd" -g $argv 'refs/stash' -- ^ /dev/null | wc -l
+    set -l isgitstashed (string trim -l (command git log --format="%gd" -g $argv 'refs/stash' -- ^ /dev/null | wc -l))
+    echo -n $isgitstashed
 end
 
 function __budspencer_prompt_git_symbols -d 'Displays the git symbols'


### PR DESCRIPTION
At some point the `git stash` test started returning spaces, strip them off so `expr` sees the return as an integer.